### PR TITLE
SystemInfoPainter: now displays number of satellites with a fix

### DIFF
--- a/plugins-dev/position/pt/lsts/neptus/plugins/position/painter/SystemInfoPainter.java
+++ b/plugins-dev/position/pt/lsts/neptus/plugins/position/painter/SystemInfoPainter.java
@@ -80,10 +80,10 @@ public class SystemInfoPainter extends ConsoleLayer {
     private static final String GPS_SIM = I18n.textc("SIM", "Simulated. Use a single small word");
 
     private static final int RECT_WIDTH = 228;
-    private static final int RECT_HEIGHT = 70;
+    private static final int RECT_HEIGHT = 80;
     private static final int MARGIN = 5;
 
-    private String strCpu, strFuel, strComms, strDisk, strGPS, strGPSFix;
+    private String strCpu, strFuel, strComms, strDisk, strGPS, strGPSFix, strFixedSat;
 
     @NeptusProperty(name = "Enable")
     public boolean enablePainter = true;
@@ -108,7 +108,7 @@ public class SystemInfoPainter extends ConsoleLayer {
 
     private long lastMessageMillis = 0;
 
-    private int cpuUsage = 0, fixQuality = 0;
+    private int cpuUsage = 0, fixQuality = 0, fixedSats = 0;
     private double batteryVoltage, current, fixHdop;
     private float fuelLevel, confidenceLevel;
     private int storageUsage;
@@ -128,6 +128,7 @@ public class SystemInfoPainter extends ConsoleLayer {
         strDisk = I18n.textc("Disk", "Use a single small word");
         strComms = I18n.textc("Comms", "Use a single small word");
         strGPS = I18n.textc("GPS", "Use a single small word");
+        strFixedSat = I18n.textc("Fixed Sats", "Use a single small word");
 
         strGPSFix = GPS_NO_FIX;
     }
@@ -179,10 +180,13 @@ public class SystemInfoPainter extends ConsoleLayer {
             txt += "<b>" + strDisk + ":</b> <font color=" + getColor(storageUsage, false, commsDead) + ">"
                     + storageUsage + "%</font><br/>";
             txt += "<b>" + strComms + ":</b> <font color=" + getColor(lastHbCount * 20, false, commsDead) + ">"
-                    + (lastHbCount * 20) + "%</font>";
-            if (showGPS)
+                    + (lastHbCount * 20) + "%</font> <br/>";
+            if (showGPS) {
                 txt += " <b>" + strGPS + ":</b> <font color=" + getColor(fixQuality, false, commsDead) + ">"
                         + strGPSFix + "</font>";
+                txt += " <b> " + strFixedSat + ":</b> <font color=" + getColor(fixQuality, false, commsDead) + ">"
+                        + fixedSats + "</font>";
+            }
             txt += "<br/>";
             txt += "</html>";
 
@@ -260,6 +264,7 @@ public class SystemInfoPainter extends ConsoleLayer {
         fixValidity = msg.getValidity();
         fixHdop = msg.getHdop();
         fixHdop = Math.round(fixHdop*100.0)/100.0;
+        fixedSats = msg.getSatellites();
 
         switch (fixType) {
             case DEAD_RECKONING:


### PR DESCRIPTION
After a request from our pilots, we now display the number of satellites (with fix) in the SystemInfoPainter. I.e. display GpsFix.satellites

![image](https://user-images.githubusercontent.com/1384876/30319522-65487970-97b0-11e7-8566-d0c26e39b901.png)
