### PR TITLE
Feature/iridium ripples gateway

### DIFF
--- a/plugins-dev/cloud/pt/lsts/ripples/RipplesPositions.java
+++ b/plugins-dev/cloud/pt/lsts/ripples/RipplesPositions.java
@@ -65,6 +65,7 @@ import pt.lsts.neptus.renderer2d.StateRenderer2D;
 import pt.lsts.neptus.types.coord.LocationType;
 import pt.lsts.neptus.util.DateTimeUtil;
 import pt.lsts.neptus.util.ImageUtils;
+import pt.lsts.neptus.util.conf.GeneralPreferences;
 
 /**
  * @author zp
@@ -74,7 +75,7 @@ import pt.lsts.neptus.util.ImageUtils;
 public class RipplesPositions extends ConsoleLayer {
 
     @NeptusProperty
-    String positionsApiUrl = "http://ripples.lsts.pt/positions";
+    String positionsApiUrl = GeneralPreferences.ripplesUrl + "/positions";
 
     ColorMap cmap = ColorMapFactory.createRedYellowGreenColorMap();
 

--- a/plugins-dev/cloud/pt/lsts/ripples/RipplesUpload.java
+++ b/plugins-dev/cloud/pt/lsts/ripples/RipplesUpload.java
@@ -101,7 +101,7 @@ public class RipplesUpload extends ConsolePanel implements ConfigurationListener
     private static final long serialVersionUID = -8036937519999303108L;
     
     private final String firebasePath = "https://neptus.firebaseio.com/";
-    private final String ripplesActiveSysUrl = "http://ripples.lsts.pt/api/v1/systems/active";
+    private final String ripplesActiveSysUrl = GeneralPreferences.ripplesUrl + "/api/v1/systems/active";
 
     private JCheckBoxMenuItem menuItem;
     private ImageIcon onIcon, offIcon;

--- a/plugins-dev/historic-data/pt/lsts/neptus/historicdata/HistoricWebAdapter.java
+++ b/plugins-dev/historic-data/pt/lsts/neptus/historicdata/HistoricWebAdapter.java
@@ -58,6 +58,7 @@ import pt.lsts.neptus.comm.manager.imc.ImcMsgManager;
 import pt.lsts.neptus.comm.manager.imc.ImcSystemsHolder;
 import pt.lsts.neptus.console.notifications.Notification;
 import pt.lsts.neptus.i18n.I18n;
+import pt.lsts.neptus.util.conf.GeneralPreferences;
 
 /**
  * @author zp
@@ -66,8 +67,8 @@ import pt.lsts.neptus.i18n.I18n;
 public class HistoricWebAdapter {
 
     private ExecutorService executor = Executors.newSingleThreadExecutor();
-    private String getURL = "http://ripples.lsts.pt/datastore/lsf";
-    private String postURL = "http://ripples.lsts.pt/datastore";
+    private String getURL = GeneralPreferences.ripplesUrl + "/datastore/lsf";
+    private String postURL = GeneralPreferences.ripplesUrl + "/datastore";
     private HttpClient client = new HttpClient();
     private long lastPoll = System.currentTimeMillis() - 1200 * 1000;
     private HistoricDataInteraction interaction;

--- a/plugins-dev/soi/pt/lsts/neptus/endurance/EnduranceWebApi.java
+++ b/plugins-dev/soi/pt/lsts/neptus/endurance/EnduranceWebApi.java
@@ -49,9 +49,11 @@ import java.util.concurrent.TimeUnit;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 
+import pt.lsts.neptus.util.conf.GeneralPreferences;
+
 public class EnduranceWebApi {
 
-	private static final String SOI_URL_DEFAULT = "http://ripples.lsts.pt/soi";
+	private static final String SOI_URL_DEFAULT = GeneralPreferences.ripplesUrl + "/soi";
 	
 	private static String soiUrl = SOI_URL_DEFAULT;
 	

--- a/plugins-dev/sunfish/pt/lsts/neptus/plugins/sunfish/awareness/HubLocationProvider.java
+++ b/plugins-dev/sunfish/pt/lsts/neptus/plugins/sunfish/awareness/HubLocationProvider.java
@@ -47,6 +47,7 @@ import pt.lsts.neptus.comm.iridium.HubIridiumMessenger;
 import pt.lsts.neptus.comm.iridium.HubIridiumMessenger.HubSystemMsg;
 import pt.lsts.neptus.console.notifications.Notification;
 import pt.lsts.neptus.plugins.update.Periodic;
+import pt.lsts.neptus.util.conf.GeneralPreferences;
 
 
 /**
@@ -56,7 +57,7 @@ import pt.lsts.neptus.plugins.update.Periodic;
 public class HubLocationProvider implements ILocationProvider {
 
     SituationAwareness parent;
-    private String systemsUrl = "http://ripples.lsts.pt/api/v1/systems/active";
+    private String systemsUrl = GeneralPreferences.ripplesUrl + "/api/v1/systems/active";
     @Override
     public void onInit(SituationAwareness instance) {
         this.parent = instance;

--- a/plugins-dev/sunfish/pt/lsts/neptus/plugins/sunfish/awareness/PositionHistory.java
+++ b/plugins-dev/sunfish/pt/lsts/neptus/plugins/sunfish/awareness/PositionHistory.java
@@ -45,6 +45,7 @@ import java.util.Vector;
 import org.apache.commons.io.FileUtils;
 
 import pt.lsts.neptus.NeptusLog;
+import pt.lsts.neptus.util.conf.GeneralPreferences;
 
 /**
  * @author zp
@@ -52,7 +53,7 @@ import pt.lsts.neptus.NeptusLog;
  */
 public class PositionHistory {
 
-    private static final String positions_url = "http://ripples.lsts.pt/api/v1/csvTag/";
+    private static final String positions_url = GeneralPreferences.ripplesUrl + "/api/v1/csvTag/";
     private static DateFormat fmt2 = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     
     public static void downloadCsv(String day, boolean force) throws Exception {

--- a/src/pt/lsts/neptus/comm/iridium/HubIridiumMessenger.java
+++ b/src/pt/lsts/neptus/comm/iridium/HubIridiumMessenger.java
@@ -57,6 +57,7 @@ import com.google.gson.Gson;
 import pt.lsts.neptus.NeptusLog;
 import pt.lsts.neptus.comm.iridium.Position.PosType;
 import pt.lsts.neptus.util.ByteUtil;
+import pt.lsts.neptus.util.conf.GeneralPreferences;
 
 /**
  * @author zp
@@ -66,7 +67,7 @@ import pt.lsts.neptus.util.ByteUtil;
 public class HubIridiumMessenger implements IridiumMessenger {
 
     protected boolean available = true;
-    protected String serverUrl = "http://ripples.lsts.pt/api/v1/";
+    protected String serverUrl = GeneralPreferences.ripplesUrl + "/api/v1/";
     // protected String serverUrl = "http://lsts-hub/api/v1/";
     protected String systemsUrl = serverUrl+"systems";
     protected String activeSystemsUrl = systemsUrl+"/active";

--- a/src/pt/lsts/neptus/comm/iridium/IridiumManager.java
+++ b/src/pt/lsts/neptus/comm/iridium/IridiumManager.java
@@ -81,7 +81,7 @@ public class IridiumManager {
         RockBlockIridiumMessenger,
         HubIridiumMessenger,
         SimulatedMessenger,
-        HerokuMessenger
+        RipplesMessenger
     }
     
     private IridiumManager() {
@@ -100,7 +100,7 @@ public class IridiumManager {
                 return hubMessenger;
             case RockBlockIridiumMessenger:
                 return rockBlockMessenger;
-            case HerokuMessenger:
+            case RipplesMessenger:
                 return ripplesMessenger;
             default:
                 return simMessenger;

--- a/src/pt/lsts/neptus/comm/iridium/RipplesIridiumMessenger.java
+++ b/src/pt/lsts/neptus/comm/iridium/RipplesIridiumMessenger.java
@@ -36,11 +36,11 @@ package pt.lsts.neptus.comm.iridium;
  * @author zp
  *
  */
-@IridiumProvider(id="heroku", name="Heroku Messenger", description="Sends Iridium messages directly via heroku ripples app.")
+@IridiumProvider(id="ripples", name="Ripples Messenger", description="Sends Iridium messages directly to ripples app.")
 public class RipplesIridiumMessenger extends HubIridiumMessenger {
 
     public RipplesIridiumMessenger() {
-        serverUrl = "http://ripples-spring.herokuapp.com/api/v1/";        
+        serverUrl = "http://104.248.168.40:9090/api/v1/";        
     }
     
 }

--- a/src/pt/lsts/neptus/comm/iridium/RipplesIridiumMessenger.java
+++ b/src/pt/lsts/neptus/comm/iridium/RipplesIridiumMessenger.java
@@ -40,7 +40,7 @@ package pt.lsts.neptus.comm.iridium;
 public class RipplesIridiumMessenger extends HubIridiumMessenger {
 
     public RipplesIridiumMessenger() {
-        serverUrl = "http://104.248.168.40:9090/api/v1/";        
+        serverUrl = "http://falkor.lsts.pt:9090/api/v1/";        
     }
     
 }

--- a/src/pt/lsts/neptus/comm/iridium/SimulatedMessenger.java
+++ b/src/pt/lsts/neptus/comm/iridium/SimulatedMessenger.java
@@ -50,6 +50,7 @@ import pt.lsts.imc.IridiumMsgRx;
 import pt.lsts.imc.IridiumMsgTx;
 import pt.lsts.neptus.NeptusLog;
 import pt.lsts.neptus.comm.manager.imc.ImcMsgManager;
+import pt.lsts.neptus.util.conf.GeneralPreferences;
 
 /**
  * @author zp
@@ -63,7 +64,7 @@ public class SimulatedMessenger implements IridiumMessenger {
 
     protected HashSet<IridiumMessageListener> listeners = new HashSet<>();
 
-    protected String serverUrl = "http://ripples.lsts.pt/api/v1/";
+    protected String serverUrl = GeneralPreferences.ripplesUrl + "/api/v1/";
     protected String messagesUrl = serverUrl+"irsim";
     protected int timeoutMillis = 10000;
 

--- a/src/pt/lsts/neptus/util/conf/GeneralPreferences.java
+++ b/src/pt/lsts/neptus/util/conf/GeneralPreferences.java
@@ -261,6 +261,13 @@ public class GeneralPreferences implements PropertiesProvider {
     public static boolean localTimeOnConsoleOn = false;
 
     // -------------------------------------------------------------------------
+    
+    @NeptusProperty(name = "Iridium Messenger", category="Iridium Communications", userLevel = LEVEL.REGULAR,
+        description = "Iridium messaging implementation")
+    public static String ripplesUrl = "http://ripples.lsts.pt";
+    
+
+    // -------------------------------------------------------------------------
     // Constructor and initialize
 
     public GeneralPreferences() {

--- a/src/pt/lsts/neptus/util/conf/GeneralPreferences.java
+++ b/src/pt/lsts/neptus/util/conf/GeneralPreferences.java
@@ -262,8 +262,8 @@ public class GeneralPreferences implements PropertiesProvider {
 
     // -------------------------------------------------------------------------
     
-    @NeptusProperty(name = "Iridium Messenger", category="Iridium Communications", userLevel = LEVEL.REGULAR,
-        description = "Iridium messaging implementation")
+    @NeptusProperty(name = "Ripples URL", category="Iridium Communications", userLevel = LEVEL.REGULAR,
+        description = "URL of the ripples web server")
     public static String ripplesUrl = "http://ripples.lsts.pt";
     
 


### PR DESCRIPTION
### Major Changes
- Replaces the Heroku Iridium gateway by a RipplesMessenger Gateway pointing to falkor.lsts.pt:9090.

### Minor Changes
- Replaces all instances of ripples.lsts.pt by GeneralPreferences.ripplesUrl so that it can be easier to migrate to another server.

### Additional Notes
In spite of receiving an HTTP 500 error message when using the Falkor server as an Iridium Gateway, the error happens due to the Rockblock service being inactive. For simulation purposes, all messages that would be sent through Iridium are available at http://falkor.lsts.pt:9090/soi/incoming/{vehicleName}?since={timestampMilliseconds}  as hexadecimal strings separated by newlines.
